### PR TITLE
Fix: Daily report should run on schedule, not on data changes

### DIFF
--- a/.github/workflows/daily_report.yml
+++ b/.github/workflows/daily_report.yml
@@ -1,10 +1,8 @@
 name: Daily Ollama Pulse Report
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'data/**'
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 8:00 AM UTC
   workflow_dispatch:
 
 permissions:
@@ -41,7 +39,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add docs/
           if ! git diff --quiet || ! git diff --staged --quiet; then
-            git commit -m "docs: update daily report $(date -u '+%Y-%m-%d')"
+            git commit -m "docs: daily report $(date -u '+%Y-%m-%d')"
             git pull --rebase origin main || {
               git rebase --abort
               git pull origin main --no-rebase


### PR DESCRIPTION
## Problem
The previous fix made the daily report trigger on every data change, which is wrong. The report generation is the FINAL step that should happen ONCE per day after all data collection is complete.

## Solution
Changed the workflow to:
- Run on a schedule: daily at 8:00 AM UTC
- Still allow manual triggering via workflow_dispatch
- Remove the push trigger on data/** paths

This way the report generates once per day with all the accumulated data from the hourly ingestion runs.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author