### PR TITLE
fix: Restore original workflow with Chicago time gate and dual cron schedules

### DIFF
--- a/.github/workflows/daily_report.yml
+++ b/.github/workflows/daily_report.yml
@@ -1,9 +1,10 @@
-name: Daily Ollama Pulse Report
+name: Ollama Pulse Daily Report
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily at 8:00 AM UTC
-  workflow_dispatch:
+    - cron: '0 21 * * *'   # 16:00 CDT (UTC-5)
+    - cron: '0 22 * * *'   # 16:00 CST (UTC-6)
+  workflow_dispatch:  # Manual trigger
 
 permissions:
   contents: write
@@ -11,35 +12,48 @@ permissions:
   id-token: write
 
 jobs:
-  generate-report:
+  daily_report:
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
-
+        
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
-
+          
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-
-      - name: Generate daily report
-        run: python scripts/generate_report.py
-
+          
+      - name: Gate by Chicago local time (ensure 16:00)
+        env:
+          TZ: America/Chicago
+        run: |
+          echo "Local time: $(date)";
+          HOUR=$(date +%H);
+          if [ "$HOUR" != "16" ]; then
+            echo "Not 16:00 local — exiting without generating report.";
+            exit 0;
+          fi
+          
+      - name: Generate themed daily report
+        run: |
+          cd scripts
+          python generate_report.py
+          
       - name: Commit and push report
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add docs/
           if ! git diff --quiet || ! git diff --staged --quiet; then
-            git commit -m "docs: daily report $(date -u '+%Y-%m-%d')"
+            git commit -m "feat(report): daily wrap-up $(date -u '+%Y-%m-%d')"
             git pull --rebase origin main || {
               git rebase --abort
               git pull origin main --no-rebase


### PR DESCRIPTION
## Summary

This PR restores the original sophisticated workflow architecture that was destroyed in commit `1da58d53`.

## What Was Broken

Commit `1da58d53` ("feat: Integrate review database with report generation") replaced the entire `daily_report.yml` workflow with the placeholder `$content`, destroying:
- Chicago time gate (16:00 CT)
- Dual cron schedules for CDT/CST timezone handling
- Proper working directory change (`cd scripts`)
- Semantic commit messages

## What This Restores

✅ **Dual Cron Schedules:**
- `0 21 * * *` - 16:00 CDT (UTC-5)
- `0 22 * * *` - 16:00 CST (UTC-6)

✅ **Chicago Time Gate:**
- Ensures report only runs at exactly 16:00 local time
- Prevents duplicate runs during DST transitions

✅ **Working Directory:**
- `cd scripts` before running `generate_report.py`
- Ensures correct path resolution

✅ **Semantic Commit Messages:**
- `feat(report): daily wrap-up YYYY-MM-DD`
- Better than generic `docs: daily report`

✅ **Kept Improvements:**
- PAT token for authentication
- Rebase logic with fallback
- Pages permissions

## Testing

- [ ] Manual workflow trigger succeeds
- [ ] Time gate prevents execution at wrong times
- [ ] Report generates at 16:00 Chicago time
- [ ] Site updates automatically

## References

- Original implementation: commit `2808062dd834314feee74830369a11b0434cee13`
- Breaking commit: `1da58d53285d5e7e3895dd709818193b053dceee`
- Analysis document: `OLLAMA_PULSE_ARCHITECTURAL_ANALYSIS.md`
- Restoration plan: `RESTORE_OLLAMA_PULSE.md`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author